### PR TITLE
[PR] Bug: timer delay when app is in background

### DIFF
--- a/src/components/PomoTimer.vue
+++ b/src/components/PomoTimer.vue
@@ -167,7 +167,7 @@ export default {
       let time = PomodoroTimer.remainingTime(seconds);
       this.mutableMinutes = Number(time.mm);
       this.mutableSeconds = Number(time.ss);
-      this.timePassed += 1;
+      this.timePassed = this.timeLimit - seconds;
       this.pointer.transform = `rotate(${360 * this.timeFraction}deg)`;
       if (time.running === false) {
         this.timePassed = -1;

--- a/src/utils/PomodoroTimer.js
+++ b/src/utils/PomodoroTimer.js
@@ -13,12 +13,12 @@ export const PomodoroTimer = {
     let interval = null;
 
     function countdown() {
-      let current = new Date();
-      let count = end - current;
+      const current = new Date();
+      const count = end - current;
 
-      let secs = Math.floor((count / 1000) % 60);
-      let mins = Math.floor((count / 1000 / 60) % 60);
-      let remainingSeconds = secs + mins * 60;
+      const secs = Math.floor((count / 1000) % 60);
+      const mins = Math.floor((count / 1000 / 60) % 60);
+      const remainingSeconds = secs + mins * 60;
 
       callback(seconds);
       seconds = remainingSeconds;

--- a/src/utils/PomodoroTimer.js
+++ b/src/utils/PomodoroTimer.js
@@ -5,20 +5,32 @@ export const PomodoroTimer = {
     seconds = seconds || 0;
     seconds = seconds + minutes * 60;
 
+    const immutableseconds = seconds
+
+    let end = new Date()
+    end.setSeconds(end.getSeconds() + immutableseconds)
+
     let interval = null;
 
     function countdown() {
+      let current = new Date();
+      let count = end - current;
+
+      let secs = Math.floor((count / 1000) % 60);
+      let mins = Math.floor((count / 1000 / 60) % 60);
+      let remainingSeconds = secs + mins * 60;
+
       callback(seconds);
-      if (seconds === 0) {
+      seconds = remainingSeconds;
+      if (seconds <= 0) {
         clearInterval(interval);
-      } else {
-        seconds--;
       }
     }
 
-    interval = setInterval(function() {
-      countdown();
-    }, 1000);
+    // Setting the interval to run every 100ms increases the accuracy of the passing seconds.
+    // This is because sometimes the program's 1000ms are slower or faster than the system clock's 1000ms.
+    // When this happens, the displayed time might skip a second due to the discrepancy.
+    interval = setInterval(countdown, 100);
 
     countdown();
     return interval;

--- a/src/utils/PomodoroTimer.js
+++ b/src/utils/PomodoroTimer.js
@@ -5,10 +5,8 @@ export const PomodoroTimer = {
     seconds = seconds || 0;
     seconds = seconds + minutes * 60;
 
-    const immutableseconds = seconds
-
     let end = new Date()
-    end.setSeconds(end.getSeconds() + immutableseconds)
+    end.setSeconds(end.getSeconds() + seconds)
 
     let interval = null;
 


### PR DESCRIPTION
The timer delay that was caused by the inaccuracy of setInterval due to JavaScript's single-threadedness should be fixed now. 
I followed the advice by https://medium.com/@abhi9bakshi/why-javascript-timer-is-unreliable-and-how-can-you-fix-it-9ff5e6d34ee0 and https://www.sitepoint.com/build-javascript-countdown-timer-no-dependencies/ to use Date objects to count down with. 

Closes #8 